### PR TITLE
Feat/us17/manage favorite recipes

### DIFF
--- a/client/src/components/ui/Icons/Icons.tsx
+++ b/client/src/components/ui/Icons/Icons.tsx
@@ -60,8 +60,8 @@ export const LanguageIcon = ({ className }: IconProps) => (
     className={`${className} transition-theme fill-none stroke-current motion-reduce:transition-none`}
     viewBox="0 0 24 24"
     strokeWidth={2}
-    stroke-linecap="round"
-    stroke-linejoin="round"
+    strokeLinecap="round"
+    strokeLinejoin="round"
     aria-hidden="true"
     focusable="false"
   >

--- a/client/src/components/ui/recipeCard/RecipeCardDetailed.tsx
+++ b/client/src/components/ui/recipeCard/RecipeCardDetailed.tsx
@@ -22,7 +22,9 @@ const RecipeCardDetailed = ({ recipe }: { recipe: RecipeDetailed }) => {
     const fetchFavoriteStatus = async () => {
       try {
         setIsLoading(true);
-        const statusRes = await fetch(`${apiUrl}/api/user/${user?.id}/favorites/${recipe.id}`);
+        const statusRes = await fetch(
+          `${apiUrl}/api/user/${user?.id}/favorites/${recipe.id}`,
+        );
         const status = await statusRes.json();
         setIsFavorite(status);
       } catch (err) {
@@ -33,7 +35,7 @@ const RecipeCardDetailed = ({ recipe }: { recipe: RecipeDetailed }) => {
     };
 
     fetchFavoriteStatus();
-  }, [user, recipe.id])
+  }, [user, recipe.id]);
 
   const handleFavorite = async () => {
     const newStatus = !isFavorite;
@@ -44,14 +46,13 @@ const RecipeCardDetailed = ({ recipe }: { recipe: RecipeDetailed }) => {
         method: newStatus ? "POST" : "PATCH",
         headers: {
           "Content-Type": "application/json",
-        }
-      })
-
+        },
+      });
     } catch (err) {
       console.log("Erreur de mise à jour du statut favoris : ", err);
       setIsFavorite(!newStatus);
     }
-  }
+  };
 
   const formatDuration = (duration: string): string => {
     if (!duration) return "";
@@ -80,7 +81,9 @@ const RecipeCardDetailed = ({ recipe }: { recipe: RecipeDetailed }) => {
 
         <div>
           <h2>{recipe.name}</h2>
-          {isLoading ? <span>Chargement des favoris</span> :
+          {isLoading ? (
+            <span>Chargement des favoris</span>
+          ) : (
             <button
               type="button"
               onClick={() => handleFavorite()}
@@ -91,10 +94,11 @@ const RecipeCardDetailed = ({ recipe }: { recipe: RecipeDetailed }) => {
               }
               aria-pressed={isFavorite}
             >
-              <HeartIcon fill={isFavorite ? "var(--light-secondary)" : "none"} />
+              <HeartIcon
+                fill={isFavorite ? "var(--light-secondary)" : "none"}
+              />
             </button>
-          }
-
+          )}
         </div>
         <div>
           <div>

--- a/client/src/components/ui/recipeCard/RecipeCardDetailed.tsx
+++ b/client/src/components/ui/recipeCard/RecipeCardDetailed.tsx
@@ -1,13 +1,57 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useAuth } from "../../../contexts/AuthContext";
 import { GuestsIcon, HeartIcon, StarIcon } from "../Icons/Icons";
 import type { RecipeDetailed } from "./data/recipeCardType";
 import "./recipeCardDetailed.css";
 
 const RecipeCardDetailed = ({ recipe }: { recipe: RecipeDetailed }) => {
+  const apiUrl = import.meta.env.VITE_API_URL;
+  const { user } = useAuth();
+
   const starIndex = [1, 2, 3, 4, 5];
   recipe.instructions?.sort((a, b) => a.stepOrder - b.stepOrder);
 
   const [isFavorite, setIsFavorite] = useState<boolean>();
+  const [isLoading, setIsLoading] = useState<boolean>();
+
+  useEffect(() => {
+    if (!user) {
+      return;
+    }
+
+    const fetchFavoriteStatus = async () => {
+      try {
+        setIsLoading(true);
+        const statusRes = await fetch(`${apiUrl}/api/user/${user?.id}/favorites/${recipe.id}`);
+        const status = await statusRes.json();
+        setIsFavorite(status);
+      } catch (err) {
+        console.log("Erreur de chargement du statut favoris : ", err);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchFavoriteStatus();
+  }, [user, recipe.id])
+
+  const handleFavorite = async () => {
+    const newStatus = !isFavorite;
+    setIsFavorite(newStatus);
+
+    try {
+      await fetch(`${apiUrl}/api/user/${user?.id}/favorites/${recipe.id}`, {
+        method: newStatus ? "POST" : "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        }
+      })
+
+    } catch (err) {
+      console.log("Erreur de mise à jour du statut favoris : ", err);
+      setIsFavorite(!newStatus);
+    }
+  }
 
   const formatDuration = (duration: string): string => {
     if (!duration) return "";
@@ -36,18 +80,21 @@ const RecipeCardDetailed = ({ recipe }: { recipe: RecipeDetailed }) => {
 
         <div>
           <h2>{recipe.name}</h2>
-          <button
-            type="button"
-            onClick={() => setIsFavorite(!isFavorite)}
-            aria-label={
-              isFavorite
-                ? "Retirer des recettes favorites"
-                : "Ajouter aux recettes favorites"
-            }
-            aria-pressed={isFavorite}
-          >
-            <HeartIcon fill={isFavorite ? "var(--light-secondary)" : "none"} />
-          </button>
+          {isLoading ? <span>Chargement des favoris</span> :
+            <button
+              type="button"
+              onClick={() => handleFavorite()}
+              aria-label={
+                isFavorite
+                  ? "Retirer des recettes favorites"
+                  : "Ajouter aux recettes favorites"
+              }
+              aria-pressed={isFavorite}
+            >
+              <HeartIcon fill={isFavorite ? "var(--light-secondary)" : "none"} />
+            </button>
+          }
+
         </div>
         <div>
           <div>

--- a/client/src/components/ui/recipeCard/RecipeCardDetailed.tsx
+++ b/client/src/components/ui/recipeCard/RecipeCardDetailed.tsx
@@ -79,24 +79,25 @@ const RecipeCardDetailed = ({ recipe }: { recipe: RecipeDetailed }) => {
 
         <div>
           <h2>{recipe.name}</h2>
-          {user && (isLoading ? (
-            <span>Chargement des favoris</span>
-          ) : (
-            <button
-              type="button"
-              onClick={() => handleFavorite()}
-              aria-label={
-                isFavorite
-                  ? "Retirer des recettes favorites"
-                  : "Ajouter aux recettes favorites"
-              }
-              aria-pressed={isFavorite}
-            >
-              <HeartIcon
-                fill={isFavorite ? "var(--light-secondary)" : "none"}
-              />
-            </button>
-          ))}
+          {user &&
+            (isLoading ? (
+              <span>Chargement des favoris</span>
+            ) : (
+              <button
+                type="button"
+                onClick={() => handleFavorite()}
+                aria-label={
+                  isFavorite
+                    ? "Retirer des recettes favorites"
+                    : "Ajouter aux recettes favorites"
+                }
+                aria-pressed={isFavorite}
+              >
+                <HeartIcon
+                  fill={isFavorite ? "var(--light-secondary)" : "none"}
+                />
+              </button>
+            ))}
         </div>
         <div>
           <div>

--- a/client/src/components/ui/recipeCard/RecipeCardDetailed.tsx
+++ b/client/src/components/ui/recipeCard/RecipeCardDetailed.tsx
@@ -79,7 +79,7 @@ const RecipeCardDetailed = ({ recipe }: { recipe: RecipeDetailed }) => {
 
         <div>
           <h2>{recipe.name}</h2>
-          {isLoading ? (
+          {user && (isLoading ? (
             <span>Chargement des favoris</span>
           ) : (
             <button
@@ -96,7 +96,7 @@ const RecipeCardDetailed = ({ recipe }: { recipe: RecipeDetailed }) => {
                 fill={isFavorite ? "var(--light-secondary)" : "none"}
               />
             </button>
-          )}
+          ))}
         </div>
         <div>
           <div>

--- a/client/src/components/ui/recipeCard/recipeCardDetailed.css
+++ b/client/src/components/ui/recipeCard/recipeCardDetailed.css
@@ -57,6 +57,7 @@
         padding: 8px;
         border: none;
         background-color: transparent;
+        cursor: pointer;
 
         svg {
           height: 24px;

--- a/client/src/components/user/login/Login.tsx
+++ b/client/src/components/user/login/Login.tsx
@@ -44,7 +44,6 @@ export default function Login() {
       console.error("Erreur serveur :", error);
       toast.error("Erreur lors de la connexion.");
     }
-
   }
 
   return (

--- a/client/src/components/user/login/Login.tsx
+++ b/client/src/components/user/login/Login.tsx
@@ -8,7 +8,7 @@ import "../login/Login.css";
 export default function Login() {
   const { login } = useAuth();
   const navigate = useNavigate();
-  const [isPending, startTransition] = useTransition();
+  const [isPending] = useTransition();
 
   async function handleSubmit(formData: FormData) {
     const data = Object.fromEntries(formData);

--- a/client/src/components/user/login/Login.tsx
+++ b/client/src/components/user/login/Login.tsx
@@ -12,38 +12,39 @@ export default function Login() {
 
   async function handleSubmit(formData: FormData) {
     const data = Object.fromEntries(formData);
-    startTransition(async () => {
-      try {
-        const apiUrl = import.meta.env.VITE_API_URL;
-        const response = await fetch(`${apiUrl}/api/login`, {
-          method: "POST",
-          credentials: "include",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(data),
-        });
 
-        const result: LoginResponse = await response.json();
+    try {
+      const apiUrl = import.meta.env.VITE_API_URL;
+      const response = await fetch(`${apiUrl}/api/login`, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+      });
 
-        if (!response.ok) {
-          toast.error(result.message || "Erreur de connexion.");
-          return;
-        }
+      const result: LoginResponse = await response.json();
 
-        login({
-          email: result.email,
-          username: result.username,
-        });
-
-        toast.success("Connexion réussie !");
-        toast.success("Vous allez être redirigé.e vers la page recettes. ");
-        setTimeout(() => {
-          navigate("/recipes");
-        }, 3000);
-      } catch (error) {
-        console.error("Erreur serveur :", error);
-        toast.error("Erreur lors de la connexion.");
+      if (!response.ok) {
+        toast.error(result.message || "Erreur de connexion.");
+        return;
       }
-    });
+
+      login({
+        id: result.id,
+        email: result.email,
+        username: result.username,
+      });
+
+      toast.success("Connexion réussie !");
+      toast.success("Vous allez être redirigé.e vers la page recettes.");
+      setTimeout(() => {
+        navigate("/recipes");
+      }, 3000);
+    } catch (error) {
+      console.error("Erreur serveur :", error);
+      toast.error("Erreur lors de la connexion.");
+    }
+
   }
 
   return (

--- a/client/src/contexts/AuthContext.tsx
+++ b/client/src/contexts/AuthContext.tsx
@@ -6,11 +6,11 @@ const AuthContext = createContext<AuthContextType | undefined>(undefined);
 export const AuthProvider = ({ children }: Children) => {
   const [user, setUser] = useState<User | null>(null);
   const [isLogged, setIsLogged] = useState(false);
-  const [isLoading, setIsLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
 
   useEffect(() => {
     const hasToken = document.cookie.includes("token=");
-
+    setIsLoading(true);
     if (!hasToken) {
       setIsLoading(false);
       console.info("Pas de token détecté — aucun refresh effectué.");
@@ -39,9 +39,6 @@ export const AuthProvider = ({ children }: Children) => {
         } else {
           setIsLogged(false);
         }
-      })
-      .catch(() => {
-        setIsLogged(false);
       })
       .finally(() => {
         setIsLoading(false);

--- a/client/src/contexts/AuthContext.tsx
+++ b/client/src/contexts/AuthContext.tsx
@@ -29,8 +29,9 @@ export const AuthProvider = ({ children }: Children) => {
         return res.json();
       })
       .then((data) => {
-        if (data?.email && data.username) {
+        if (data.id && data.email && data.username) {
           setUser({
+            id: data.id,
             email: data.email,
             username: data.username,
           });

--- a/client/src/pages/recipes/Recipes.tsx
+++ b/client/src/pages/recipes/Recipes.tsx
@@ -146,7 +146,7 @@ const Recipes = () => {
       <div>
         {filteredRecipes?.map((recipe) => {
           return (
-            <Link key={recipe.id} to={`/recipes/${recipe.id}`}>
+            <Link key={recipe.id} to={`/recipe/${recipe.id}`}>
               <RecipeCard variant="square" recipe={recipe} />
             </Link>
           );

--- a/client/src/types/Auth.ts
+++ b/client/src/types/Auth.ts
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 
 export type User = {
-  id: number;
+  id?: number;
   email: string;
   username: string;
 };
@@ -19,6 +19,7 @@ export interface Children {
 }
 
 export interface LoginResponse {
+  id: number;
   username: string;
   email: string;
   firstName: string;

--- a/client/src/types/Auth.ts
+++ b/client/src/types/Auth.ts
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 
 export type User = {
+  id: number;
   email: string;
   username: string;
 };

--- a/server/src/modules/favorite/favoriteActions.ts
+++ b/server/src/modules/favorite/favoriteActions.ts
@@ -75,7 +75,6 @@ const removeFavorite: RequestHandler = async (req, res, next) => {
     const updatedFavorite = await favoriteRepository.updateFavorite(
       userId,
       recipeId,
-      false,
     );
 
     if (updatedFavorite) {

--- a/server/src/modules/favorite/favoriteActions.ts
+++ b/server/src/modules/favorite/favoriteActions.ts
@@ -1,0 +1,104 @@
+import type { RequestHandler } from "express";
+import type { Favorite } from "../../types/express/favorite";
+import favoriteRepository from "./favoriteRepository";
+
+const browseFavoritesByUser: RequestHandler = async (req, res, next) => {
+  try {
+    const userId = Number(req.params.userId);
+
+    if (Number.isNaN(userId)) {
+      return res.status(400).send("Invalid userId");
+    }
+
+    const favorites = await favoriteRepository.readAll(userId);
+
+    res.json(favorites as Favorite[]);
+  } catch (err) {
+    next(err);
+  }
+};
+
+const readSingleFavorite: RequestHandler = async (req, res, next) => {
+  try {
+    const userId = Number(req.params.userId);
+    const recipeId = Number(req.params.recipeId);
+
+    if (Number.isNaN(userId) || Number.isNaN(recipeId)) {
+      return res.status(400).send("Invalid userId or recipeId");
+    }
+
+    const rows = await favoriteRepository.readSingleFavorite(userId, recipeId);
+
+    if (rows.length > 0) {
+      res.json(rows[0].is_favorite === 1);
+    } else {
+      res.json(false);
+    }
+  } catch (err) {
+    next(err);
+  }
+};
+
+const addFavorite: RequestHandler = async (req, res, next) => {
+  try {
+    const userId = Number(req.params.userId);
+    const recipeId = Number(req.params.recipeId);
+
+    if (Number.isNaN(userId) || Number.isNaN(recipeId)) {
+      return res.status(400).send("Invalid userId or recipeId");
+    }
+
+    const newFavorite = await favoriteRepository.createFavorite(
+      userId,
+      recipeId,
+    );
+
+    if (newFavorite) {
+      res.status(201).json({ message: "Created", favorites: newFavorite });
+    } else {
+      res.status(404).json({ message: "Favorite not created" });
+    }
+  } catch (err) {
+    next(err);
+  }
+};
+
+const removeFavorite: RequestHandler = async (req, res, next) => {
+  try {
+    const userId = Number(req.params.userId);
+    const recipeId = Number(req.params.recipeId);
+
+    if (Number.isNaN(userId) || Number.isNaN(recipeId)) {
+      return res.status(400).send("Invalid userId or recipeId");
+    }
+
+    const updatedFavorite = await favoriteRepository.updateFavorite(
+      userId,
+      recipeId,
+      false,
+    );
+
+    if (updatedFavorite) {
+      res
+        .status(200)
+        .json(
+          `Recipe ${recipeId} has been successfully removed from user ${userId} favorites.`,
+        );
+    } else {
+      res
+        .status(404)
+        .json(
+          `Impossible to remove recipe ${recipeId} from user ${userId} favorites.`,
+        );
+    }
+  } catch (err) {
+    next(err);
+  }
+};
+
+export default {
+  addFavorite,
+  browseFavoritesByUser,
+  readSingleFavorite,
+  removeFavorite,
+};

--- a/server/src/modules/favorite/favoriteRepository.ts
+++ b/server/src/modules/favorite/favoriteRepository.ts
@@ -30,27 +30,27 @@ class FavoriteRepository {
     return rows;
   }
 
-  async createFavorite(userId: number, recipeId: number, isFavorite: boolean) {
+  async createFavorite(userId: number, recipeId: number) {
     const [result] = await databaseClient.query<Result>(
       `
       INSERT INTO save (user_id, recipe_id, is_favorite)
       VALUES (?,?,?)
       ON DUPLICATE KEY UPDATE is_favorite = ?
       `,
-      [userId, recipeId, true],
+      [userId, recipeId, true, true],
     );
 
     return result.affectedRows;
   }
 
-  async updateFavorite(userId: number, recipeId: number, isFavorite: boolean) {
+  async updateFavorite(userId: number, recipeId: number) {
     const [result] = await databaseClient.query<Result>(
       `
       UPDATE save
       SET is_favorite = ?
       WHERE user_id = ? AND recipe_id = ?
       `,
-      [isFavorite, userId, recipeId],
+      [false, userId, recipeId],
     );
 
     return result.affectedRows;

--- a/server/src/modules/favorite/favoriteRepository.ts
+++ b/server/src/modules/favorite/favoriteRepository.ts
@@ -1,0 +1,60 @@
+import databaseClient, {
+  type Result,
+  type Rows,
+} from "../../../database/client";
+
+class FavoriteRepository {
+  async readAll(userId: number) {
+    const [rows] = await databaseClient.query<Rows>(
+      `
+      SELECT user_id, recipe_id, is_favorite
+      FROM save
+      WHERE user_id = ? AND is_favorite = ?
+      `,
+      [userId, true],
+    );
+
+    return rows;
+  }
+
+  async readSingleFavorite(userId: number, recipeId: number) {
+    const [rows] = await databaseClient.query<Rows>(
+      `
+      SELECT is_favorite
+      FROM save
+      WHERE user_id = ? AND recipe_id = ?
+      `,
+      [userId, recipeId],
+    );
+
+    return rows;
+  }
+
+  async createFavorite(userId: number, recipeId: number, isFavorite: boolean) {
+    const [result] = await databaseClient.query<Result>(
+      `
+      INSERT INTO save (user_id, recipe_id, is_favorite)
+      VALUES (?,?,?)
+      ON DUPLICATE KEY UPDATE is_favorite = ?
+      `,
+      [userId, recipeId, true],
+    );
+
+    return result.affectedRows;
+  }
+
+  async updateFavorite(userId: number, recipeId: number, isFavorite: boolean) {
+    const [result] = await databaseClient.query<Result>(
+      `
+      UPDATE save
+      SET is_favorite = ?
+      WHERE user_id = ? AND recipe_id = ?
+      `,
+      [isFavorite, userId, recipeId],
+    );
+
+    return result.affectedRows;
+  }
+}
+
+export default new FavoriteRepository();

--- a/server/src/router.ts
+++ b/server/src/router.ts
@@ -6,10 +6,10 @@ const router = express.Router();
 // Define Your API Routes Here
 /* ************************************************************************* */
 import authActions from "./modules/auth/authActions";
+import favoriteActions from "./modules/favorite/favoriteActions";
 import recipesActions from "./modules/recipes/recipesActions";
 import auth from "./utils/auth";
 import validation from "./utils/validation";
-import favoriteActions from "./modules/favorite/favoriteActions";
 
 /* Login */
 router.post(

--- a/server/src/router.ts
+++ b/server/src/router.ts
@@ -37,22 +37,22 @@ router.get("/api/recipes/:id", recipesActions.readRecipeDetailed);
 /* Favorite Recipes */
 
 router.post(
-  "api/user/:userId/favorites/:recipeId/",
+  "/api/user/:userId/favorites/:recipeId/",
   favoriteActions.addFavorite,
 );
 
 router.get(
-  "api/user/:userId/favorites/",
+  "/api/user/:userId/favorites/",
   favoriteActions.browseFavoritesByUser,
 );
 
 router.get(
-  "api/user/:userId/favorites/:recipeId",
+  "/api/user/:userId/favorites/:recipeId",
   favoriteActions.readSingleFavorite,
 );
 
 router.patch(
-  "api/user/:userId/favorites/:recipeId/",
+  "/api/user/:userId/favorites/:recipeId/",
   favoriteActions.removeFavorite,
 );
 

--- a/server/src/router.ts
+++ b/server/src/router.ts
@@ -9,7 +9,9 @@ import authActions from "./modules/auth/authActions";
 import recipesActions from "./modules/recipes/recipesActions";
 import auth from "./utils/auth";
 import validation from "./utils/validation";
+import favoriteActions from "./modules/favorite/favoriteActions";
 
+/* Login */
 router.post(
   "/api/login",
   validation.authValidation,
@@ -26,9 +28,33 @@ router.post(
 );
 router.get("/api/refresh", auth.refreshToken);
 
+/* Recipes */
+
 router.get("/api/last-recipes", recipesActions.browseLastRecipes);
 router.get("/api/recipes", recipesActions.browseSearchRecipes);
 router.get("/api/recipes/:id", recipesActions.readRecipeDetailed);
+
+/* Favorite Recipes */
+
+router.post(
+  "api/user/:userId/favorites/:recipeId/",
+  favoriteActions.addFavorite,
+);
+
+router.get(
+  "api/user/:userId/favorites/",
+  favoriteActions.browseFavoritesByUser,
+);
+
+router.get(
+  "api/user/:userId/favorites/:recipeId",
+  favoriteActions.readSingleFavorite,
+);
+
+router.patch(
+  "api/user/:userId/favorites/:recipeId/",
+  favoriteActions.removeFavorite,
+);
 
 /* ************************************************************************* */
 

--- a/server/src/types/express/favorite.ts
+++ b/server/src/types/express/favorite.ts
@@ -1,0 +1,5 @@
+export type Favorite = {
+  user_id: number;
+  recipe_id: number;
+  is_favorite: boolean;
+};

--- a/server/src/utils/auth.ts
+++ b/server/src/utils/auth.ts
@@ -58,6 +58,7 @@ const login: RequestHandler = async (req, res) => {
     });
 
     res.status(200).json({
+      id: user.id,
       email: user.email,
       username: user.username,
     });


### PR DESCRIPTION
## Feature : Favorite recipe management

This PR introduces **favorite recipe management** for logged-in users. It enhances the user experience by allowing registered users to manage their favorite recipes directly from the recipe view.

---

### What's been done

* [x] Use a previously added a heart icon on the `RecipeCardDetailed` component for users to **add/remove recipes from favorites** with a single click.
* [x] Disabled the favorite icon for unauthenticated users.
* [x] Updated the `useAuth` context to include the user's `id` for backend operations.
* [x] Backend: created new routes to **Create, Read, and Update** favorite recipes.
* [x] Backend logic:

  * **Add favorite**: insert a new row into the `save` table if it doesn't exist, or set `is_favorite = true` if it does to avoid duplicates.
  * **Remove favorite**: update `is_favorite` to false (do not delete the row, as the table also stores cooked recipes).

---

### Next steps (not in this PR)

* [ ] Add **security middleware** to ensure requests are made by the authorized user.
