### PR TITLE
Feat/us14/display all favorite recipes

### DIFF
--- a/client/src/components/layouts/AppLayout/appLayout.css
+++ b/client/src/components/layouts/AppLayout/appLayout.css
@@ -11,6 +11,7 @@
     grid-area: 1 / 2 / 2 / 3;
   }
   main {
+    height: calc(100dvh - 60px - 60px);
     grid-area: 2 / 2 / 3 / 3;
     padding: 16px;
   }
@@ -33,6 +34,7 @@
     }
 
     main {
+      height: initial;
       padding: 8px;
       margin-bottom: 70px;
     }

--- a/client/src/components/newRecipes/NewRecipes.css
+++ b/client/src/components/newRecipes/NewRecipes.css
@@ -13,7 +13,7 @@
     grid-area: 1 / 1 / 2 / 2;
     text-align: center;
     font-size: 1.5rem;
-    font-weight: 200;
+    font-weight: 400;
   }
 
   h3 {
@@ -227,10 +227,7 @@
 
 @media screen and (min-width: 900px) {
   .new-recipes {
-    width: 560px;
-    height: 700px;
-    overflow-y: scroll;
-    scrollbar-width: none;
+    overflow-y: auto;
 
     form {
       row-gap: 16px;

--- a/client/src/components/ui/recipeCard/recipeCardRect.css
+++ b/client/src/components/ui/recipeCard/recipeCardRect.css
@@ -2,7 +2,6 @@
   width: 224px;
   height: 80px;
   display: flex;
-  justify-content: space-between;
   align-items: center;
   gap: 8px;
   background-color: var(--text-light);
@@ -33,7 +32,9 @@
   }
 
   figcaption {
+    padding-right: 0.25rem;
     font-size: 12px;
+    font-weight: 500;
     color: var(--text-dark);
   }
 }

--- a/client/src/pages/home/home.css
+++ b/client/src/pages/home/home.css
@@ -1,25 +1,28 @@
 .home-section {
-  hgroup {
+  > hgroup {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+
     h1 {
       display: flex;
       justify-content: center;
 
       img {
-        width: 200px;
+        height: 200px;
+        object-fit: contain;
       }
     }
 
     p {
-      font-size: 1.2rem;
+      font-size: 1rem;
       font-weight: bold;
       text-align: center;
-      padding: 64px 16px 32px 16px;
-      color: #7f976c;
+      color: var(--light-primary);
     }
   }
 
-  article {
-    padding: 1.5rem 1rem 2rem 1rem;
+  > article {
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -27,7 +30,7 @@
 
     h2 {
       text-align: center;
-      color: #7f976c;
+      color: var(--light-primary);
     }
 
     > div {
@@ -43,7 +46,7 @@
           position: absolute;
           top: 110%;
           left: 50%;
-          background: #7f976c;
+          background: var(--light-primary);
           color: white;
           padding: 5px 10px;
           border-radius: 8px;
@@ -69,24 +72,27 @@
 
 @media screen and (min-width: 768px) {
   .home-section {
-    hgroup {
-      h1 {
-        padding-top: 72px;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-around;
 
+    > hgroup {
+      height: 50%;
+
+      h1 {
         img {
           width: 600px;
         }
       }
 
       p {
-        padding-top: 96px;
-        font-size: 2.1rem;
+        font-size: 1.5rem;
       }
     }
 
-    article {
+    > article {
       h2 {
-        padding-top: 32px;
         font-size: 1.8rem;
       }
 
@@ -95,7 +101,6 @@
         justify-content: center;
         align-items: center;
         gap: 4rem;
-        padding-top: 32px;
         flex-wrap: wrap;
       }
     }
@@ -111,7 +116,15 @@
 }
 
 @media screen and (max-width: 768px) {
-  article > div {
-    flex-direction: column;
+  .home-section {
+    > hgroup {
+      img {
+        max-width: 100%;
+      }
+    }
+
+    > article > div {
+      flex-direction: column;
+    }
   }
 }

--- a/client/src/pages/kitchen/myrecipes/MyRecipes.css
+++ b/client/src/pages/kitchen/myrecipes/MyRecipes.css
@@ -2,15 +2,22 @@
   width: 100%;
   display: grid;
   grid-template-columns: 1fr;
-  grid-template-rows: repeat(3, 1fr);
+  grid-template-rows: repeat(3, auto);
   place-items: center;
   gap: 16px;
 
   > article {
+    width: 100%;
     background-color: var(--light-primary);
     border-radius: 16px;
     padding: 16px;
     color: var(--text-light);
+
+    > h2 {
+      text-align: center;
+      font-size: 1.5rem;
+      font-weight: 400;
+    }
   }
 
   > :nth-child(1) {
@@ -19,28 +26,70 @@
   > :nth-child(2) {
     grid-area: 3 / 1 / 4 / 2;
   }
+
+  > :nth-child(1),
+  > :nth-child(2) {
+    display: flex;
+    flex-direction: column;
+
+    > div {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+      gap: 1rem;
+
+      > span {
+        text-align: center;
+      }
+
+      figure {
+        place-self: center;
+      }
+    }
+  }
+
   > :nth-child(3) {
     grid-area: 1 / 1 / 2 / 2;
   }
 }
 
-@media (min-width: 900px) {
+@media (min-width: 1100px) {
   .my-recipes {
-    grid-template-columns: repeat(2, 1fr);
+    height: 100%;
+    grid-template-columns: repeat(2, auto);
     grid-template-rows: repeat(2, 1fr);
 
     > article {
       padding: 24px;
+
+      > h2 {
+        font-size: 2rem;
+      }
     }
 
-    :nth-child(1) {
+    > :nth-child(1) {
       grid-area: 1 / 1 / 2 / 2;
     }
-    :nth-child(2) {
+
+    > :nth-child(2) {
       grid-area: 2 / 1 / 3 / 2;
     }
-    :nth-child(3) {
+
+    > :nth-child(1),
+    > :nth-child(2) {
+      height: 100%;
+
+      > div {
+        height: 100%;
+        overflow-y: auto;
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+        gap: 1rem;
+      }
+    }
+
+    > :nth-child(3) {
       grid-area: 1 / 2 / 3 / 3;
+      height: 100%;
     }
   }
 }

--- a/client/src/pages/kitchen/myrecipes/MyRecipes.tsx
+++ b/client/src/pages/kitchen/myrecipes/MyRecipes.tsx
@@ -44,11 +44,9 @@ const MyRecipes = () => {
             isLoadingFav ? (
               <span>Chargement des favoris</span>
             ) : favoriteList && favoriteList.length > 0 ? (
-
               favoriteList?.map((recipe) => (
                 <RecipeCard key={recipe.id} variant="rect" recipe={recipe} />
               ))
-
             ) : (
               <span>Aucune recette favorite</span>
             )
@@ -66,7 +64,6 @@ const MyRecipes = () => {
             isLoadingFav ? (
               <span>Chargement des recettes ajoutées</span>
             ) : addedList && addedList.length > 0 ? (
-
               addedList?.map((recipe) => (
                 <RecipeCard key={recipe.id} variant="rect" recipe={recipe} />
               ))

--- a/client/src/pages/kitchen/myrecipes/MyRecipes.tsx
+++ b/client/src/pages/kitchen/myrecipes/MyRecipes.tsx
@@ -9,6 +9,7 @@ const MyRecipes = () => {
   const apiUrl = import.meta.env.VITE_API_URL;
   const { user } = useAuth();
   const [favoriteList, setFavoriteList] = useState<RecipeBase[]>();
+  const [addedList, setAddedList] = useState<RecipeBase[]>();
   const [isLoadingFav, setIsLoadingFav] = useState<boolean>();
 
   useEffect(() => {
@@ -38,29 +39,46 @@ const MyRecipes = () => {
     <section className="my-recipes">
       <article>
         <h2>Mes recettes favorites</h2>
-        {user ? (
-          isLoadingFav ? (
-            <span>Chargement des favoris</span>
+        <div>
+          {user ? (
+            isLoadingFav ? (
+              <span>Chargement des favoris</span>
+            ) : favoriteList && favoriteList.length > 0 ? (
+
+              favoriteList?.map((recipe) => (
+                <RecipeCard key={recipe.id} variant="rect" recipe={recipe} />
+              ))
+
+            ) : (
+              <span>Aucune recette favorite</span>
+            )
           ) : (
-            favoriteList?.map((recipe) => (
-              <RecipeCard key={recipe.id} variant="rect" recipe={recipe} />
-            ))
-          )
-        ) : (
-          <span>
-            Veuillez vous connecter pour visualiser vos recettes favorites
-          </span>
-        )}
+            <span>
+              Veuillez vous connecter pour visualiser vos recettes favorites
+            </span>
+          )}
+        </div>
       </article>
       <article>
         <h2>Mes recettes ajoutées</h2>
-        {user ? (
-          <></>
-        ) : (
-          <span>
-            Veuillez vous connecter pour visualiser vos recettes ajoutées
-          </span>
-        )}
+        <div>
+          {user ? (
+            isLoadingFav ? (
+              <span>Chargement des recettes ajoutées</span>
+            ) : addedList && addedList.length > 0 ? (
+
+              addedList?.map((recipe) => (
+                <RecipeCard key={recipe.id} variant="rect" recipe={recipe} />
+              ))
+            ) : (
+              <span>Aucune recette ajoutée</span>
+            )
+          ) : (
+            <span>
+              Veuillez vous connecter pour visualiser vos recettes ajoutées
+            </span>
+          )}
+        </div>
       </article>
       <NewRecipes />
     </section>

--- a/client/src/pages/kitchen/myrecipes/MyRecipes.tsx
+++ b/client/src/pages/kitchen/myrecipes/MyRecipes.tsx
@@ -11,6 +11,7 @@ const MyRecipes = () => {
   const [favoriteList, setFavoriteList] = useState<RecipeBase[]>();
   const [addedList, setAddedList] = useState<RecipeBase[]>();
   const [isLoadingFav, setIsLoadingFav] = useState<boolean>();
+  const [isLoadingAdded, setIsLoadingAdded] = useState<boolean>();
 
   useEffect(() => {
     if (!user) {
@@ -32,6 +33,22 @@ const MyRecipes = () => {
       }
     };
 
+    const fetchAdded = async () => {
+      try {
+        setIsLoadingAdded(true);
+        const addedListRes = await fetch(
+          `${apiUrl}/api/user/${user.id}/my-recipes`,
+        );
+        const addedList = await addedListRes.json();
+        setAddedList(addedList);
+      } catch (err) {
+        console.log("Erreur de chargement des recettes ajoutées : ", err);
+      } finally {
+        setIsLoadingAdded(false);
+      }
+    };
+
+    fetchAdded();
     fetchFavorites();
   }, [user]);
 
@@ -61,7 +78,7 @@ const MyRecipes = () => {
         <h2>Mes recettes ajoutées</h2>
         <div>
           {user ? (
-            isLoadingFav ? (
+            isLoadingAdded ? (
               <span>Chargement des recettes ajoutées</span>
             ) : addedList && addedList.length > 0 ? (
               addedList?.map((recipe) => (

--- a/client/src/pages/kitchen/myrecipes/MyRecipes.tsx
+++ b/client/src/pages/kitchen/myrecipes/MyRecipes.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from "react";
 import NewRecipes from "../../../components/newRecipes/NewRecipes";
-import { useAuth } from "../../../contexts/AuthContext";
-import "./MyRecipes.css";
 import RecipeCard from "../../../components/ui/recipeCard/RecipeCard";
 import type { RecipeBase } from "../../../components/ui/recipeCard/data/recipeCardType";
+import { useAuth } from "../../../contexts/AuthContext";
+import "./MyRecipes.css";
 
 const MyRecipes = () => {
   const apiUrl = import.meta.env.VITE_API_URL;

--- a/client/src/pages/kitchen/myrecipes/MyRecipes.tsx
+++ b/client/src/pages/kitchen/myrecipes/MyRecipes.tsx
@@ -1,14 +1,66 @@
-import "./MyRecipes.css";
+import { useEffect, useState } from "react";
 import NewRecipes from "../../../components/newRecipes/NewRecipes";
+import { useAuth } from "../../../contexts/AuthContext";
+import "./MyRecipes.css";
+import RecipeCard from "../../../components/ui/recipeCard/RecipeCard";
+import type { RecipeBase } from "../../../components/ui/recipeCard/data/recipeCardType";
 
 const MyRecipes = () => {
+  const apiUrl = import.meta.env.VITE_API_URL;
+  const { user } = useAuth();
+  const [favoriteList, setFavoriteList] = useState<RecipeBase[]>();
+  const [isLoadingFav, setIsLoadingFav] = useState<boolean>();
+
+  useEffect(() => {
+    if (!user) {
+      return;
+    }
+
+    const fetchFavorites = async () => {
+      try {
+        setIsLoadingFav(true);
+        const favListRes = await fetch(
+          `${apiUrl}/api/user/${user.id}/favorites`,
+        );
+        const favList = await favListRes.json();
+        setFavoriteList(favList);
+      } catch (err) {
+        console.log("Erreur de chargement des recettes favorites : ", err);
+      } finally {
+        setIsLoadingFav(false);
+      }
+    };
+
+    fetchFavorites();
+  }, [user]);
+
   return (
     <section className="my-recipes">
       <article>
         <h2>Mes recettes favorites</h2>
+        {user ? (
+          isLoadingFav ? (
+            <span>Chargement des favoris</span>
+          ) : (
+            favoriteList?.map((recipe) => (
+              <RecipeCard key={recipe.id} variant="rect" recipe={recipe} />
+            ))
+          )
+        ) : (
+          <span>
+            Veuillez vous connecter pour visualiser vos recettes favorites
+          </span>
+        )}
       </article>
       <article>
         <h2>Mes recettes ajoutées</h2>
+        {user ? (
+          <></>
+        ) : (
+          <span>
+            Veuillez vous connecter pour visualiser vos recettes ajoutées
+          </span>
+        )}
       </article>
       <NewRecipes />
     </section>

--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -201,6 +201,13 @@ CREATE TABLE save (
     ON DELETE CASCADE
 );
 
+INSERT INTO save (user_id, recipe_id, is_favorite)
+VALUES  (1, 1, 1),
+        (1, 3, 1),
+        (2, 2, 1),
+        (2, 3, 1)
+;
+
 CREATE TABLE quantity (
   ingredient_id INT NOT NULL,
   recipe_id INT NOT NULL,

--- a/server/src/modules/favorite/favoriteActions.ts
+++ b/server/src/modules/favorite/favoriteActions.ts
@@ -1,6 +1,7 @@
 import type { RequestHandler } from "express";
 import type { Favorite } from "../../types/express/favorite";
 import favoriteRepository from "./favoriteRepository";
+import type { RecipeBase } from "../../types/express/recipe";
 
 const browseFavoritesByUser: RequestHandler = async (req, res, next) => {
   try {
@@ -12,7 +13,7 @@ const browseFavoritesByUser: RequestHandler = async (req, res, next) => {
 
     const favorites = await favoriteRepository.readAll(userId);
 
-    res.json(favorites as Favorite[]);
+    res.json(favorites as RecipeBase[]);
   } catch (err) {
     next(err);
   }

--- a/server/src/modules/favorite/favoriteActions.ts
+++ b/server/src/modules/favorite/favoriteActions.ts
@@ -1,7 +1,6 @@
 import type { RequestHandler } from "express";
-import type { Favorite } from "../../types/express/favorite";
-import favoriteRepository from "./favoriteRepository";
 import type { RecipeBase } from "../../types/express/recipe";
+import favoriteRepository from "./favoriteRepository";
 
 const browseFavoritesByUser: RequestHandler = async (req, res, next) => {
   try {

--- a/server/src/modules/favorite/favoriteRepository.ts
+++ b/server/src/modules/favorite/favoriteRepository.ts
@@ -7,9 +7,11 @@ class FavoriteRepository {
   async readAll(userId: number) {
     const [rows] = await databaseClient.query<Rows>(
       `
-      SELECT user_id, recipe_id, is_favorite
-      FROM save
-      WHERE user_id = ? AND is_favorite = ?
+      SELECT 
+        r.id as id, r.name, r.image
+      FROM recipe as r
+      LEFT JOIN save as s ON id = s.recipe_id
+      WHERE s.user_id = ? AND s.is_favorite = ?
       `,
       [userId, true],
     );

--- a/server/src/modules/recipes/recipesActions.ts
+++ b/server/src/modules/recipes/recipesActions.ts
@@ -1,8 +1,9 @@
 import type { RequestHandler } from "express";
-import recipesRepository, {
-  type AvailableFilters,
-  type RecipesParams,
-} from "./recipesRepository";
+import type {
+  AvailableFilters,
+  RecipesParams,
+} from "../../types/express/recipe";
+import recipesRepository from "./recipesRepository";
 
 const browseSearchRecipes: RequestHandler = async (req, res, next) => {
   try {

--- a/server/src/modules/recipes/recipesRepository.ts
+++ b/server/src/modules/recipes/recipesRepository.ts
@@ -1,27 +1,5 @@
 import databaseClient, { type Rows } from "../../../database/client";
-
-interface RecipeBase {
-  id: number;
-  name: string;
-  image: string;
-}
-
-export type AvailableFilters =
-  | "name"
-  | "price"
-  | "duration"
-  | "usersRanking"
-  | "ecoRanking"
-  | "page";
-
-export interface RecipesParams {
-  name?: string;
-  price?: string;
-  duration?: string;
-  usersRanking?: string;
-  ecoRanking?: string;
-  page?: string;
-}
+import type { RecipeBase, RecipesParams } from "../../types/express/recipe";
 
 class RecipesRepository {
   async readSearchRecipes(recipesParams: RecipesParams) {

--- a/server/src/types/express/recipe.ts
+++ b/server/src/types/express/recipe.ts
@@ -1,0 +1,22 @@
+export interface RecipeBase {
+  id: number;
+  name: string;
+  image: string;
+}
+
+export type AvailableFilters =
+  | "name"
+  | "price"
+  | "duration"
+  | "usersRanking"
+  | "ecoRanking"
+  | "page";
+
+export interface RecipesParams {
+  name?: string;
+  price?: string;
+  duration?: string;
+  usersRanking?: string;
+  ecoRanking?: string;
+  page?: string;
+}


### PR DESCRIPTION
## Favorite Recipes display

This PR adds the display of **favorite recipes** for a logged-in user on the “My Recipes” page.

---

### What's been done

* [x] Set up **frontend logic** in the `kitchen/myrecipes` page to fetch and display favorite recipes.
* [x] Updated the **backend** to return the correct data for a user’s favorite recipes.
* [x] **Refactored types**: moved recipe-related types to `types/express/` and adjusted imports accordingly.
* [x] Unified **UI style** for favorite and added recipes to match the overall layout of the `MyRecipes` section.
* [x] Fixed `<main>` height to ensure no global scroll, only internal scroll where needed (e.g., long lists or forms).
* [x] Updated the **homepage layout** to reflect recent height adjustments and maintain consistency.

---

### Next steps (not in this PR)

* Add display of **user-added recipes** (logic and layout are already prepared, only fetch and backend are missing).
