### PR TITLE
Feat/us15/display added recipes

### DIFF
--- a/server/database/schema.sql
+++ b/server/database/schema.sql
@@ -35,10 +35,11 @@ CREATE TABLE recipe (
    ON DELETE SET NULL
 );
 
-INSERT INTO recipe (name, image, price, is_validated, guest_number, nutrition_average, eco_average, duration)
-VALUES ("Riz au curry haricots coco et champignons", "https://img.cuisineaz.com/660x495/2015/10/22/i100924-riz-champignons.webp", 1, true, 5, 4.6, 4.3, "000:25:00"),
-       ("Biscuits sans farine au cacao parfumé", "https://resize.elle.fr/portrait_320_webp/var/plain_site/storage/images/elle-a-table/recettes-de-cuisine/biscuits-sans-farine-au-cacao-parfume-3593609/85388120-1-fre-FR/Biscuits-sans-farine-au-cacao-parfume.jpg", 1, true, 6, 4.2, 3.9, "000:25:00"),
-       ("Blanquette de veau", "https://assets.afcdn.com/recipe/20190529/93191_w600.jpg", 2, true, 4, 4.2, 3.9, "002:15:00");
+INSERT INTO recipe (name, image, price, is_validated, guest_number, nutrition_average, eco_average, duration, user_id)
+VALUES 
+    ("Riz au curry haricots coco et champignons", "https://img.cuisineaz.com/660x495/2015/10/22/i100924-riz-champignons.webp", 1, true, 5, 4.6, 4.3, "000:25:00", 1),
+    ("Biscuits sans farine au cacao parfumé", "https://resize.elle.fr/portrait_320_webp/var/plain_site/storage/images/elle-a-table/recettes-de-cuisine/biscuits-sans-farine-au-cacao-parfume-3593609/85388120-1-fre-FR/Biscuits-sans-farine-au-cacao-parfume.jpg", 1, true, 6, 4.2, 3.9, "000:25:00", 1),
+    ("Blanquette de veau", "https://assets.afcdn.com/recipe/20190529/93191_w600.jpg", 2, true, 4, 4.2, 3.9, "002:15:00", 2);
 
 CREATE TABLE eco_score (
   id INT PRIMARY KEY AUTO_INCREMENT NOT NULL,

--- a/server/src/modules/recipes/recipesActions.ts
+++ b/server/src/modules/recipes/recipesActions.ts
@@ -1,6 +1,7 @@
 import type { RequestHandler } from "express";
 import type {
   AvailableFilters,
+  RecipeBase,
   RecipesParams,
 } from "../../types/express/recipe";
 import recipesRepository from "./recipesRepository";
@@ -39,6 +40,7 @@ const browseLastRecipes: RequestHandler = async (req, res, next) => {
     next(err);
   }
 };
+
 const readRecipeDetailed: RequestHandler = async (req, res, next) => {
   try {
     const recipeId = Number(req.params.id);
@@ -54,4 +56,25 @@ const readRecipeDetailed: RequestHandler = async (req, res, next) => {
   }
 };
 
-export default { browseSearchRecipes, browseLastRecipes, readRecipeDetailed };
+const browseAddedRecipesByUser: RequestHandler = async (req, res, next) => {
+  try {
+    const userId = Number(req.params.userId);
+
+    if (Number.isNaN(userId)) {
+      return res.status(400).send("Invalid userId");
+    }
+
+    const addedRecipes = await recipesRepository.readAddedByUser(userId);
+
+    res.json(addedRecipes as RecipeBase[]);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export default {
+  browseSearchRecipes,
+  browseLastRecipes,
+  readRecipeDetailed,
+  browseAddedRecipesByUser,
+};

--- a/server/src/modules/recipes/recipesRepository.ts
+++ b/server/src/modules/recipes/recipesRepository.ts
@@ -102,6 +102,7 @@ class RecipesRepository {
     );
     return rows;
   }
+
   async readById(id: number) {
     const [rows] = await databaseClient.query<Rows>(
       `SELECT 
@@ -159,6 +160,20 @@ GROUP BY r.id
       [id],
     );
     return rows[0] || null;
+  }
+
+  async readAddedByUser(userId: number) {
+    const [rows] = await databaseClient.query<Rows>(
+      `
+      SELECT 
+        id, name, image
+      FROM recipe
+      WHERE user_id = ?
+      `,
+      [userId],
+    );
+
+    return rows;
   }
 }
 

--- a/server/src/router.ts
+++ b/server/src/router.ts
@@ -33,6 +33,10 @@ router.get("/api/refresh", auth.refreshToken);
 router.get("/api/last-recipes", recipesActions.browseLastRecipes);
 router.get("/api/recipes", recipesActions.browseSearchRecipes);
 router.get("/api/recipes/:id", recipesActions.readRecipeDetailed);
+router.get(
+  "/api/user/:userId/my-recipes/",
+  recipesActions.browseAddedRecipesByUser,
+);
 
 /* Favorite Recipes */
 


### PR DESCRIPTION
## Display User's recipes

This PR implements the display of user's in the "My Recipes" page, under the section "My Added Recipes", following the same structure and logic as the favorite recipes.
It allows users to see all the recipes they've personally created in one place, with a consistent and unified user experience.

---

### What's been done

* [x] Display of **added recipes** for the logged-in user, using the same frontend format as favorite recipes for visual consistency.
* [x] **Backend endpoint** added to fetch the user's added recipes via a simple `GET` request.
* [x] Updated **database records** so that existing recipes are now linked to a specific user, enabling proper display.

---

### Next steps
* Add the ability for users to **edit or delete their added recipes** from the same interface.
