### PR TITLE
Feat/us29/basic menu

### DIFF
--- a/client/src/components/ui/menuCard/MenuCard.tsx
+++ b/client/src/components/ui/menuCard/MenuCard.tsx
@@ -1,0 +1,30 @@
+import { Link } from "react-router";
+import "./menuCard.css";
+import type { MenuCardType } from "./menuCardType";
+
+const MenuCard = ({ item }: { item: MenuCardType }) => {
+  return (
+    <>
+      {item.isAvailable ? (
+        <Link
+          to={item.path}
+          className="menu-card available"
+          aria-label={`Allez vers ${item.label}`}
+        >
+          <span>{item.label}</span>
+        </Link>
+      ) : (
+        <div
+          className="menu-card not-available"
+          aria-disabled="true"
+          tabIndex={-1}
+        >
+          <span>{item.label}</span>
+          <span>Prochainement</span>
+        </div>
+      )}
+    </>
+  );
+};
+
+export default MenuCard;

--- a/client/src/components/ui/menuCard/menuCard.css
+++ b/client/src/components/ui/menuCard/menuCard.css
@@ -1,0 +1,39 @@
+.menu-card {
+  display: grid;
+  grid-template-rows: 1fr auto 1fr;
+  height: 140px;
+  width: 210px;
+  border-radius: 1rem;
+  color: var(--text-light);
+
+  > span {
+    place-self: center;
+  }
+
+  > :nth-child(1) {
+    grid-row: 2 / 3;
+    font-size: 1.25rem;
+    font-weight: 600;
+  }
+
+  > :nth-child(2) {
+    grid-row: 3 / 4;
+    font-size: 0.75rem;
+  }
+}
+
+.menu-card.available {
+  background-color: var(--light-primary);
+  cursor: pointer;
+  transition: 0.3s;
+
+  &:hover {
+    transform: scale(1.02);
+  }
+}
+
+.menu-card.not-available {
+  background-color: var(--light-primary);
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/client/src/components/ui/menuCard/menuCardType.ts
+++ b/client/src/components/ui/menuCard/menuCardType.ts
@@ -1,0 +1,8 @@
+export interface MenuCardType {
+  id: number;
+  label: string;
+  isAvailable: boolean;
+  path: string;
+}
+
+export type MenuCardList = MenuCardType[];

--- a/client/src/pages/kitchen/Kitchen.tsx
+++ b/client/src/pages/kitchen/Kitchen.tsx
@@ -1,6 +1,6 @@
 import MenuCard from "../../components/ui/menuCard/MenuCard";
-import { kitchenMenuList } from "./kitchenMenuData";
 import "./kitchen.css";
+import { kitchenMenuList } from "./kitchenMenuData";
 
 const Kitchen = () => {
   return (

--- a/client/src/pages/kitchen/Kitchen.tsx
+++ b/client/src/pages/kitchen/Kitchen.tsx
@@ -1,27 +1,21 @@
-import { Link } from "react-router";
+import MenuCard from "../../components/ui/menuCard/MenuCard";
+import { kitchenMenuList } from "./kitchenMenuData";
+import "./kitchen.css";
 
 const Kitchen = () => {
   return (
-    <div>
-      <h2>Kitchen :</h2>
+    <section className="my-kitchen">
+      <h2>Ma Cuisine</h2>
       <ul>
-        <li>
-          <Link to="/kitchen/myrecipes">My Recipes</Link>
-        </li>
-        <li>
-          <Link to="/kitchen/fridge">Fridge</Link>
-        </li>
-        <li>
-          <Link to="/kitchen/shoppinglist">Shopping List</Link>
-        </li>
-        <li>
-          <Link to="/kitchen/settings">Settings</Link>
-        </li>
-        <li>
-          <Link to="/kitchen/planner">Planner</Link>
-        </li>
+        {kitchenMenuList.map((menuItem) => {
+          return (
+            <li key={menuItem.id}>
+              <MenuCard item={menuItem} />
+            </li>
+          );
+        })}
       </ul>
-    </div>
+    </section>
   );
 };
 

--- a/client/src/pages/kitchen/kitchen.css
+++ b/client/src/pages/kitchen/kitchen.css
@@ -18,11 +18,10 @@
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
-    align-items: space-around;
+    align-content: center;
     gap: 1rem;
 
     li {
-      place-self: center;
       list-style: none;
     }
   }

--- a/client/src/pages/kitchen/kitchen.css
+++ b/client/src/pages/kitchen/kitchen.css
@@ -1,0 +1,45 @@
+.my-kitchen {
+  height: 100%;
+  padding-bottom: 40px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  h2 {
+    color: var(--light-primary);
+    padding: 1rem 0;
+    font-size: 2rem;
+  }
+
+  ul {
+    height: 100%;
+    width: 100%;
+    max-width: 900px;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: space-around;
+    gap: 1rem;
+
+    li {
+      place-self: center;
+      list-style: none;
+    }
+  }
+}
+
+@media screen and (min-width: 600px) {
+  .my-kitchen {
+    ul {
+      gap: 2rem;
+    }
+  }
+}
+
+@media screen and (min-width: 800px) {
+  .my-kitchen {
+    ul {
+      gap: 3rem;
+    }
+  }
+}

--- a/client/src/pages/kitchen/kitchenMenuData.ts
+++ b/client/src/pages/kitchen/kitchenMenuData.ts
@@ -1,0 +1,34 @@
+import type { MenuCardList } from "../../components/ui/menuCard/menuCardType";
+
+export const kitchenMenuList: MenuCardList = [
+  {
+    id: 1,
+    label: "Mes recettes",
+    isAvailable: true,
+    path: "/kitchen/myrecipes",
+  },
+  {
+    id: 2,
+    label: "Réfrigérateur",
+    isAvailable: false,
+    path: "/kitchen/fridge",
+  },
+  {
+    id: 3,
+    label: "Liste de courses",
+    isAvailable: false,
+    path: "/kitchen/shoppinglist",
+  },
+  {
+    id: 4,
+    label: "Paramètres",
+    isAvailable: false,
+    path: "/kitchen/settings",
+  },
+  {
+    id: 5,
+    label: "Calendrier",
+    isAvailable: true,
+    path: "/kitchen/planner",
+  },
+];

--- a/client/src/pages/products/Products.tsx
+++ b/client/src/pages/products/Products.tsx
@@ -1,18 +1,21 @@
-import { Link } from "react-router";
+import MenuCard from "../../components/ui/menuCard/MenuCard";
+import { productsMenuList } from "./productsMenuData";
+import "./products.css";
 
 const Products = () => {
   return (
-    <div>
-      Products :
+    <section className="products">
+      <h2>Produits</h2>
       <ul>
-        <li>
-          <Link to="/products/seasonnal">Seasonnal</Link>
-        </li>
-        <li>
-          <Link to="/products/analysis">Analysis</Link>
-        </li>
+        {productsMenuList.map((menuItem) => {
+          return (
+            <li key={menuItem.id}>
+              <MenuCard item={menuItem} />
+            </li>
+          );
+        })}
       </ul>
-    </div>
+    </section>
   );
 };
 

--- a/client/src/pages/products/Products.tsx
+++ b/client/src/pages/products/Products.tsx
@@ -1,6 +1,6 @@
 import MenuCard from "../../components/ui/menuCard/MenuCard";
-import { productsMenuList } from "./productsMenuData";
 import "./products.css";
+import { productsMenuList } from "./productsMenuData";
 
 const Products = () => {
   return (

--- a/client/src/pages/products/products.css
+++ b/client/src/pages/products/products.css
@@ -1,0 +1,45 @@
+.products {
+  height: 100%;
+  padding-bottom: 40px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  h2 {
+    color: var(--light-primary);
+    padding: 1rem 0;
+    font-size: 2rem;
+  }
+
+  ul {
+    height: 100%;
+    width: 100%;
+    max-width: 900px;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: space-around;
+    gap: 1rem;
+
+    li {
+      place-self: center;
+      list-style: none;
+    }
+  }
+}
+
+@media screen and (min-width: 600px) {
+  .products {
+    ul {
+      gap: 2rem;
+    }
+  }
+}
+
+@media screen and (min-width: 800px) {
+  .products {
+    ul {
+      gap: 3rem;
+    }
+  }
+}

--- a/client/src/pages/products/products.css
+++ b/client/src/pages/products/products.css
@@ -18,11 +18,10 @@
     display: flex;
     flex-wrap: wrap;
     justify-content: center;
-    align-items: space-around;
+    align-content: center;
     gap: 1rem;
 
     li {
-      place-self: center;
       list-style: none;
     }
   }

--- a/client/src/pages/products/productsMenuData.ts
+++ b/client/src/pages/products/productsMenuData.ts
@@ -1,0 +1,16 @@
+import type { MenuCardList } from "../../components/ui/menuCard/menuCardType";
+
+export const productsMenuList: MenuCardList = [
+  {
+    id: 1,
+    label: "Produits de saison",
+    isAvailable: false,
+    path: "/products/seasonnal",
+  },
+  {
+    id: 2,
+    label: "Analyse",
+    isAvailable: false,
+    path: "/products/analysis",
+  },
+];


### PR DESCRIPTION
### Basic and Accessible Submenu display

This PR implements a **basic and accessible submenu display** for two sections of the website: **Kitchen** and **Products**. It ensures consistency with the app's overall UI and design system.

---

### What's been done

* [x] Created a `MenuCard` component with basic layout, styling, and accessibility features.
* [x] Implemented the **Kitchen Menu** section using the new card component.
* [x] Implemented the **Products Menu** section using the same approach to maintain design consistency.

---

### Design & UX considerations

* Maintains a **simple and clear structure**, aligned with the rest of the app.
* Preserves **accessibility best practices** for interactive elements.
* Style and layout match the existing app to ensure a cohesive user experience.

---

### Next steps

* Investigate and fix layout issues affecting multiple pages cause by the update of `main` height on small desktop screens.
